### PR TITLE
DAO update: handle `toMany` relationship when fetching forward refs

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -642,6 +642,9 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
       const itemReferencesByEntityTypeName: {[entityTypeName: string]: {pointer: string, id: Id}[]} = {}
       for (const relationship of relationships.filter((r) => r.storage == 'ref')) {
         const pathInItemsArray = relationship.path.replace(/^\$/, '$[*]')
+        if (relationship.toMany) {
+          pathInItemsArray = `${pathInItemsArray}[*]`
+        }
         let referencePointers: string[] = jsonPath({path: pathInItemsArray, json: items, resultType: 'pointer'}) as string[]
         if (pointersToExpand) {
           referencePointers = _.intersection(referencePointers, pointersToExpand)


### PR DESCRIPTION
One-to-many relationships were being ignored in `fetchForwardRelationships` function because of missing array index wildcard ("[*]") in the path, so that will now be appended as needed.