### PR TITLE
Drop duplicate IDs prior to fetching records

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -389,7 +389,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
           FetchOptions
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = [...new Set(parentIds)]
+        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref': {
             // TODO Use the schema's foreign key path instead of having one in the REST collection config.
@@ -492,10 +492,10 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
         {client = null, returnMatchingList = true, propertyBlacklist = []} = {}
     ) {
       let items: Entity[] = []
-      ids = [...new Set(ids)]
+      ids = _.uniq(ids)
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = [...new Set(parentIds)]
+        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO
@@ -533,7 +533,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
     fetchOneById: async function(id: Id, parentIds = [], {client = null, propertyBlacklist = []} = {}) {
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = [...new Set(parentIds)]
+        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO Ensure that the item belongs to the parent's collection.

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -389,6 +389,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
           FetchOptions
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
+        parentIds = [...new Set(parentIds)]
         switch (collection.persistence) {
           case 'inverse-ref': {
             // TODO Use the schema's foreign key path instead of having one in the REST collection config.
@@ -491,8 +492,10 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
         {client = null, returnMatchingList = true, propertyBlacklist = []} = {}
     ) {
       let items: Entity[] = []
+      ids = [...new Set(ids)]
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
+        parentIds = [...new Set(parentIds)]
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO
@@ -530,6 +533,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
     fetchOneById: async function(id: Id, parentIds = [], {client = null, propertyBlacklist = []} = {}) {
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
+        parentIds = [...new Set(parentIds)]
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO Ensure that the item belongs to the parent's collection.

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -389,7 +389,6 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
           FetchOptions
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref': {
             // TODO Use the schema's foreign key path instead of having one in the REST collection config.
@@ -495,7 +494,6 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
       ids = _.uniq(ids)
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO
@@ -533,7 +531,6 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
     fetchOneById: async function(id: Id, parentIds = [], {client = null, propertyBlacklist = []} = {}) {
       const collection = _.last(parentCollections)
       if (collection && parentDaos.length > 0 && parentIds.length > 0) {
-        parentIds = _.uniq(parentIds)
         switch (collection.persistence) {
           case 'inverse-ref':
             // TODO Ensure that the item belongs to the parent's collection.


### PR DESCRIPTION
Most queries generated by DAO end up having duplicate IDs which do not affect the query result, but are not needed, add clutter to logs, and may impact performance in some cases. Dropping duplicates from these arrays of IDs by converting to a Set and back, prior to generating the resulting SQL query.