### PR TITLE
Fix method for fetching multiple items by ID from subcollection

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -514,9 +514,15 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
             }
           }
             break
-          case 'ref':
-            // TODO
-            items = []
+          case 'ref': {
+            const parent = await _.last(parentDaos).fetchOneById(_.last(parentIds), parentIds.slice(0, -1))
+            if (!parent) {
+              return [] // TODO Or error?
+            } else {
+              const collectionMemberIds = (_.get(parent, collection.subpath) || []).filter((x: any) => ids.includes(x))
+              return await rawDao.fetchById(collectionMemberIds, {client, propertyBlacklist})
+            }
+          }
             break
           case 'subdocument': {
             // TODO Revisit

--- a/src/dao.ts
+++ b/src/dao.ts
@@ -509,7 +509,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
             if (!parent) {
               items = [] // TODO Or error?
             } else {
-              items = (_.get(parent, collection.name) || []).find((x: any) => x?._id && ids.includes(x._id))
+              items = (_.get(parent, collection.name) || []).filter((x: any) => x?._id && ids.includes(x._id))
             }
           }
         }


### PR DESCRIPTION
Updates to DAO's `fetchByIDs` method:

- The use of `find` when fetching from subcollections was only returning a single item, updating to `filter` to return all matching records.
- Adding support for collections with persistence type `ref` and `inverse-ref`