### PR TITLE
Subcollection filtering

### DIFF
--- a/src/dao.ts
+++ b/src/dao.ts
@@ -25,6 +25,7 @@ import {
   tailPath
 } from './paths.js'
 import {
+  applyQuery,
   QueryClause,
   queryClauseIsAnd,
   QueryOrder
@@ -272,8 +273,7 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
               const collectionMembers = await rawDao.fetch({
                 l: {path: `${collection.foreignKeyPath}.$ref`}, r: {constant: parent._id}
               }) as Entity[]
-              // TODO Implement collection filtering by query
-              results = collectionMembers.filter((x) => false)
+              results = collectionMembers.filter((x) => query ? applyQuery(x, query) : true)
               // TODO Apply order
               // TODO Apply limit
             }
@@ -287,23 +287,21 @@ const makeDao = async function(entityType: EntityType, options: DaoOptionsInput 
             } else {
               const collectionMemberIds = _.get(parent, collection.subpath) || []
               const collectionMembers = await rawDao.fetchById(collectionMemberIds, {client, propertyBlacklist})
-              results = collectionMembers.filter((x) =>
-                // TODO Implement collection filtering by query
-                false
-              )
+              results = collectionMembers.filter((x) => query ? applyQuery(x, query) : true)
               // TODO Apply order
               // TODO Apply limit
             }
           }
             break
-            case 'subdocument': {
+          case 'subdocument': {
             const parent = await _.last(parentDaos)
                 .fetchOneById(_.last(parentIds), parentIds.slice(0, -1), {client, propertyBlacklist})
             if (!parent) {
               results = [] // TODO Or error?
             } else {
               // TODO Implement collection filtering by query
-              results = (_.get(parent, collection.subpath) || []).filter(() => false)
+              results = (_.get(parent, collection.subpath) || [])
+                  .filter((x: any) => query ? applyQuery(x, query) : true)
               // TODO Apply order
               // TODO Apply limit
             }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 export type QueryConstant = string | number | boolean | null
 export type QueryFullTextSearchContext = 'default'
 export type QueryPath = string
@@ -107,7 +109,7 @@ export function queryClauseIsBetween(clause: QueryClause): clause is QueryBetwee
   return (clause as QueryBetweenClause).operator == 'between'
 }
 
-export function queryClauseIsComparisonn(clause: QueryClause): clause is QueryComparisonClause {
+export function queryClauseIsComparison(clause: QueryClause): clause is QueryComparisonClause {
   const operator = (clause as QueryComparisonClause).operator
   return !queryClauseIsFullTextSearch(clause) && [undefined, '=', '<', '>', '<=', '>=', '!='].includes(operator)
 }
@@ -125,7 +127,7 @@ export function queryClauseIsFullTextSearch(clause: QueryClause): clause is Quer
 }
 
 export function queryClauseIsSimple(clause: QueryClause): clause is QuerySimpleClause {
-  return queryClauseIsBetween(clause) || queryClauseIsComparisonn(clause) || queryClauseIsIn(clause)
+  return queryClauseIsBetween(clause) || queryClauseIsComparison(clause) || queryClauseIsIn(clause)
       || queryClauseIsFullTextSearch(clause)
 }
 
@@ -139,4 +141,100 @@ export function queryClauseIsOr(clause: QueryClause): clause is QueryOrClause {
 
 export function queryClauseIsNot(clause: QueryClause): clause is QueryNotClause {
   return (clause as QueryNotClause).not != null
+}
+
+export function calculateExpression(context: any, expression: QueryExpression): any {
+  if (queryExpressionIsCoalesce(expression)) {
+    for (const subexpression of expression.coalesce) {
+      if (subexpression != null) {
+        return subexpression
+      }
+    }
+    return null
+  } else if (queryExpressionIsConstant(expression)) {
+    return expression.constant
+  } else if (queryExpressionIsConstantList(expression)) {
+    return expression.constant
+  } else if (queryExpressionIsFullText(expression)) {
+    return expression.text
+  } else if (queryExpressionIsFunction(expression)) {
+    throw 'Functions are not supported in query expressions outside a database context.'
+  } else if (queryExpressionIsOperator(expression)) {
+    throw 'Operators are not supported in query expressions outside a database context.'
+  } else if (queryExpressionIsPath(expression)) {
+    return _.get(context, expression.path)
+    // TODO Should we support type enforcement when the optional sqlType property is present?
+  } else if (queryExpressionIsRange(expression)) {
+    return expression.range
+  }
+}
+
+export function applyQuery(x: any, query: QueryClause): boolean {
+  if (query === true) {
+    return true
+  } else if (query === false) {
+    return false
+  } else if (queryClauseIsAnd(query)) {
+    for (const subclause of query.and) {
+      if (!applyQuery(x, subclause)) {
+        return false
+      }
+      return true
+    }
+  } else if (queryClauseIsOr(query)) {
+    for (const subclause of query.or) {
+      if (applyQuery(x, subclause)) {
+        return true
+      }
+      return false
+    }
+  } else if (queryClauseIsNot(query)) {
+    return !applyQuery(x, query.not)
+  } else { // queryClauseIsSimple
+    if (queryClauseIsBetween(query)) {
+      const left = calculateExpression(x, query.l)
+      const right = calculateExpression(x, query.r)
+      if (!_.isArray(right) || right.length != 2) {
+        throw 'For "between" queries, the right side must be a range (an array of size 2).'
+      }
+      if (typeof left == 'number') {
+        if (typeof right[0] != 'number' || typeof right[1] != 'number') {
+          throw 'For "between" queries, the range must consist of numbers if the left side is a number.'
+        }
+        return right[0] <= left && left <= right[1]
+      } else if (typeof left == 'string') {
+        return right[0].toString() <= left && left <= right[1].toString()
+      } else {
+        return right[0] <= left && left <= right[1]
+      }
+    } else if (queryClauseIsComparison(query)) {
+      const left = calculateExpression(x, query.l)
+      const right = calculateExpression(x, query.r)
+      switch (query.operator) {
+        case '<':
+          return left < right
+        case '>':
+          return left > right
+        case '<=':
+          return left <= right
+        case '>=':
+          return left >= right
+        case '!=':
+          return left != right
+        case '=':
+        default:
+          return left == right
+      }
+    } else if (queryClauseIsIn(query)) {
+      const left = calculateExpression(x, query.l)
+      const right = calculateExpression(x, query.r)
+      if (!_.isArray(right)) {
+        throw 'For "in" queries, the right side must be an array.'
+      }
+      return right.includes(left)
+    } else if (queryClauseIsFullTextSearch(query)) {
+      throw 'Full text search queries are not supported outside a database context.'
+    }
+  }
+  return false
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -130,6 +130,18 @@ export function makeSchemaConcrete(
     if ((schema as any).entityType || (schema as any).foreignKey || (schema as any).storage) {
       Object.assign(concreteSchema, _.pick(schema, ['entityType', 'foreignKey', 'storage']));
     }
+
+    // Add $ref to the concrete subschema's properties. This is  workaround, whereas what we really want to do is stop
+    // producing a concrete schema in advance for a type; instead we might produce concrete schemas only when needed,
+    // based on a schema context and taking into account what relationships have been expanded.
+    // TODO If concreteSchema's type is not object, this doesn't make sense. In fact we should only allow $refs to
+    // object schemas.
+    if ((concreteSchema as any).type == 'object') {
+      (concreteSchema as any).properties ||= {}
+      if (!(concreteSchema as any).properties.$ref) {
+        (concreteSchema as any).properties.$ref = {type: 'string'}
+      }
+    }
   } else {
     switch ((schema as any).type) {
       case 'object':


### PR DESCRIPTION
Subcollection filtering has been left unimplemented until now.

Filter queries are typically translated into SQL WHERE clauses. But in order to filter subcollections, queries need to be applied to objects already loaded into memory.